### PR TITLE
Added missing geofence options, for Android and some refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.1.4
+* Added new fields to Zone class
+* Updated the list of constants for the new zone fields
+* Methods called on both Kotlin and Dart sides will be identified by String constants
+* Added GeofenceEventType.findById static function
+* Updated GeofenceEventTypeIntX.toGeofenceEventType to use GeofenceEventType.findById
+* Updated GeofenceForegroundService.subscribeToLocationUpdates to include permissions checking
+* Refactored GeofenceForegroundServicePlugin
+
 ## 1.1.3
 
 * Handle error responses

--- a/README.md
+++ b/README.md
@@ -125,6 +125,14 @@ Future<void> initPlatformState() async {
         id: 'zone#1_id',
         radius: 10000, // measured in meters
         coordinates: timesSquarePolygon,
+        triggers: [
+          GeofenceEventType.dwell,
+          GeofenceEventType.enter,
+          GeofenceEventType.exit
+        ], // Currently, only available on Android
+        expirationDuration: const Duration(days: 1), // Currently, only available on Android
+        dwellLoiteringDelay: const Duration(hours: 1), // Currently, only available on Android
+        initialTrigger: GeofenceEventType.enter, // Currently, only available on Android
       ),
     );
   }

--- a/android/src/main/kotlin/com/f2fk/geofence_foreground_service/ApiMethods.kt
+++ b/android/src/main/kotlin/com/f2fk/geofence_foreground_service/ApiMethods.kt
@@ -1,0 +1,15 @@
+package com.f2fk.geofence_foreground_service
+
+// Class which keeps the names of the plugin's available methods.
+//
+// This is to avoid writing literals when checking the method called.
+class ApiMethods {
+    companion object  {
+        const val startGeofencingService: String = "startGeofencingService"
+        const val stopGeofencingService: String = "stopGeofencingService"
+        const val isForegroundServiceRunning: String = "isForegroundServiceRunning"
+        const val addGeofence: String = "addGeofence"
+        const val addGeoFences: String = "addGeoFences"
+        const val removeGeofence: String = "removeGeofence"
+    }
+}

--- a/android/src/main/kotlin/com/f2fk/geofence_foreground_service/Constants.kt
+++ b/android/src/main/kotlin/com/f2fk/geofence_foreground_service/Constants.kt
@@ -10,6 +10,10 @@ class Constants {
         const val latitude: String = "latitude"
         const val longitude: String = "longitude"
         const val notificationResponsivenessMs: String = "notification_responsiveness_ms"
+        const val fenceTriggers: String = "fence_triggers"
+        const val fenceExpirationDuration: String = "fence_expiration_duration"
+        const val dwellLoiteringDelay: String = "fence_dwell_loitering_delay"
+        const val initialTrigger: String = "fence_initial_trigger"
 
         const val geofenceAction: String = "geofence_action"
 

--- a/android/src/main/kotlin/com/f2fk/geofence_foreground_service/GeofenceForegroundService.kt
+++ b/android/src/main/kotlin/com/f2fk/geofence_foreground_service/GeofenceForegroundService.kt
@@ -1,13 +1,16 @@
 package com.f2fk.geofence_foreground_service
 
+import android.Manifest
 import android.app.Service
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION
 import android.os.Build
 import android.os.IBinder
 import android.os.Looper
 import android.util.Log
+import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
 import androidx.work.Data
 import androidx.work.ExistingWorkPolicy
@@ -169,6 +172,23 @@ class GeofenceForegroundService : Service() {
     }
 
     private fun subscribeToLocationUpdates() {
+        if (ActivityCompat.checkSelfPermission(
+                this,
+                Manifest.permission.ACCESS_FINE_LOCATION
+            ) != PackageManager.PERMISSION_GRANTED && ActivityCompat.checkSelfPermission(
+                this,
+                Manifest.permission.ACCESS_COARSE_LOCATION
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
+            // TODO: Consider calling
+            //    ActivityCompat#requestPermissions
+            // here to request the missing permissions, and then overriding
+            //   public void onRequestPermissionsResult(int requestCode, String[] permissions,
+            //                                          int[] grantResults)
+            // to handle the case where the user grants the permission. See the documentation
+            // for ActivityCompat#requestPermissions for more details.
+            return
+        }
         fusedLocationProviderClient.requestLocationUpdates(
             locationRequest,
             locationCallback,

--- a/android/src/main/kotlin/com/f2fk/geofence_foreground_service/builders/GeofenceBuilder.kt
+++ b/android/src/main/kotlin/com/f2fk/geofence_foreground_service/builders/GeofenceBuilder.kt
@@ -1,0 +1,29 @@
+package com.f2fk.geofence_foreground_service.builders
+
+import android.util.Log
+import com.f2fk.geofence_foreground_service.interfaces.Builder
+import com.f2fk.geofence_foreground_service.models.Zone
+import com.f2fk.geofence_foreground_service.utils.calculateCenter
+import com.google.android.gms.location.Geofence
+import com.google.android.gms.maps.model.LatLng
+
+class GeofenceBuilder(private val zone: Zone) : Builder<Geofence> {
+    override fun build(): Geofence {
+        val centerCoordinate: LatLng = calculateCenter(zone.coordinates ?: emptyList())
+        val builder = Geofence.Builder()
+            .setRequestId(zone.zoneId)
+            .setCircularRegion(
+                centerCoordinate.latitude,
+                centerCoordinate.longitude,
+                zone.radius,
+                )
+            .setExpirationDuration(zone.expirationDuration ?: Geofence.NEVER_EXPIRE)
+            .setTransitionTypes(zone.triggers)
+            .setLoiteringDelay(zone.dwellLoiteringDelay ?: 0)
+        if (zone.notificationResponsivenessMs != null) {
+            Log.v("addGeofence", "Setting notification responsiveness to ${zone.notificationResponsivenessMs}")
+            builder.setNotificationResponsiveness(zone.notificationResponsivenessMs)
+        }
+        return builder.build()
+    }
+}

--- a/android/src/main/kotlin/com/f2fk/geofence_foreground_service/builders/GeofenceRequestBuilder.kt
+++ b/android/src/main/kotlin/com/f2fk/geofence_foreground_service/builders/GeofenceRequestBuilder.kt
@@ -1,0 +1,12 @@
+package com.f2fk.geofence_foreground_service.builders
+
+import com.f2fk.geofence_foreground_service.interfaces.Builder
+import com.google.android.gms.location.Geofence
+import com.google.android.gms.location.GeofencingRequest
+
+class GeofencingRequestBuilder(private val geofence: Geofence, private val initialTrigger: Int?): Builder<GeofencingRequest> {
+    override fun build(): GeofencingRequest = GeofencingRequest.Builder()
+    .setInitialTrigger(initialTrigger ?: GeofencingRequest.INITIAL_TRIGGER_ENTER)
+    .addGeofence(geofence)
+    .build()
+}

--- a/android/src/main/kotlin/com/f2fk/geofence_foreground_service/interfaces/Builder.kt
+++ b/android/src/main/kotlin/com/f2fk/geofence_foreground_service/interfaces/Builder.kt
@@ -1,0 +1,5 @@
+package com.f2fk.geofence_foreground_service.interfaces
+
+interface Builder<T> {
+    fun build() : T
+}

--- a/android/src/main/kotlin/com/f2fk/geofence_foreground_service/models/Zone.kt
+++ b/android/src/main/kotlin/com/f2fk/geofence_foreground_service/models/Zone.kt
@@ -1,10 +1,10 @@
 package com.f2fk.geofence_foreground_service.models
 
 import com.f2fk.geofence_foreground_service.Constants
+import com.f2fk.geofence_foreground_service.utils.Utils
 import com.google.android.gms.maps.model.LatLng
 import java.io.Serializable
 import java.util.ArrayList
-
 class ZonesList(
     val zones: ArrayList<Zone>?
 ) : Serializable {
@@ -25,16 +25,10 @@ class ZonesList(
     companion object {
         fun fromJson(json: Map<String, Any>): ZonesList {
             val zones = mutableListOf<Zone>()
-
-            (json[Constants.zones] as List<Map<String, Any>>).forEach {
-                zones.add(
-                    Zone.fromJson(it)
-                )
+            (Utils.cast<List<Map<String, Any>>>(json[Constants.zones])).forEach {
+                zones.add(Zone.fromJson(it))
             }
-
-            return ZonesList(
-                zones.toCollection(ArrayList<Zone>())
-            )
+            return ZonesList(zones.toCollection(ArrayList<Zone>()))
         }
     }
 }
@@ -43,7 +37,11 @@ class Zone(
     val zoneId: String,
     val radius: Float,
     val coordinates: ArrayList<LatLng>?,
-    val notificationResponsivenessMs: Int?
+    val notificationResponsivenessMs: Int?,
+    val triggers: Int,
+    val expirationDuration: Long?,
+    val dwellLoiteringDelay: Int?,
+    val initialTrigger: Int?
 ) : Serializable {
     fun toJson(): Map<String, Any> {
         val result = mutableMapOf<String, Any>()
@@ -59,6 +57,20 @@ class Zone(
         if (notificationResponsivenessMs != null) {
             result[Constants.notificationResponsivenessMs] = notificationResponsivenessMs
         }
+        // We will convert the even triggers back to a list of integers, just as we receive them
+        // inside 'fromJson' function
+        val triggersList = mutableListOf<Int>()
+        Utils.availableTriggers.forEach { if ((it and triggers) != 0) triggersList.add(it) }
+        result[Constants.fenceTriggers] = triggersList
+        if (expirationDuration != null) {
+            result[Constants.fenceExpirationDuration] = expirationDuration
+        }
+        if (dwellLoiteringDelay != null) {
+            result[Constants.dwellLoiteringDelay] = dwellLoiteringDelay
+        }
+        if (initialTrigger != null) {
+            result[Constants.initialTrigger] = initialTrigger
+        }
 
         return result
     }
@@ -66,21 +78,23 @@ class Zone(
     companion object {
         fun fromJson(json: Map<String, Any>): Zone {
             val coordinates = mutableListOf<LatLng>()
-
-            (json[Constants.coordinates] as List<Map<String, Double>>).forEach {
-                coordinates.add(
-                    LatLng(
-                        it[Constants.latitude]!!,
-                        it[Constants.longitude]!!
-                    )
-                )
+            (Utils.cast<List<Map<String, Double>>>(json[Constants.coordinates])).forEach {
+                coordinates.add(LatLng(it[Constants.latitude]!!,it[Constants.longitude]!!))
             }
+
+            var fenceTriggers = Utils.cast<List<Int>?>(json[Constants.fenceTriggers])
+            if (fenceTriggers == null) fenceTriggers = Utils.availableTriggers
 
             return Zone(
                 json[Constants.id] as String,
                 (json[Constants.radius] as Number).toFloat(),
                 coordinates.toCollection(ArrayList<LatLng>()),
-                (json[Constants.notificationResponsivenessMs] as Number?)?.toInt()
+                (json[Constants.notificationResponsivenessMs] as Number?)?.toInt(),
+                // The event triggers are passed as a bitwise-OR operation value.
+                fenceTriggers.fold(0) { acc, trigger -> acc or trigger },
+                (json[Constants.fenceExpirationDuration] as Number?)?.toLong(),
+                (json[Constants.dwellLoiteringDelay] as Number?)?.toInt(),
+                (json[Constants.initialTrigger] as Number?)?.toInt(),
             )
         }
     }

--- a/android/src/main/kotlin/com/f2fk/geofence_foreground_service/models/Zone.kt
+++ b/android/src/main/kotlin/com/f2fk/geofence_foreground_service/models/Zone.kt
@@ -57,7 +57,7 @@ class Zone(
         if (notificationResponsivenessMs != null) {
             result[Constants.notificationResponsivenessMs] = notificationResponsivenessMs
         }
-        // We will convert the even triggers back to a list of integers, just as we receive them
+        // We will convert the event triggers back to a list of integers, just as we receive them
         // inside 'fromJson' function
         val triggersList = mutableListOf<Int>()
         Utils.availableTriggers.forEach { if ((it and triggers) != 0) triggersList.add(it) }

--- a/android/src/main/kotlin/com/f2fk/geofence_foreground_service/utils/Utils.kt
+++ b/android/src/main/kotlin/com/f2fk/geofence_foreground_service/utils/Utils.kt
@@ -1,0 +1,24 @@
+package com.f2fk.geofence_foreground_service.utils
+
+import com.google.android.gms.location.Geofence
+
+/// Contains multiple utilities
+class Utils {
+    companion object {
+        // Us it to cast to different types without warnings showing.
+        @Suppress("UNCHECKED_CAST")
+        fun <T> cast(value: Any?) : T = value as T
+
+        // The list of available triggers for geofences
+        //
+        // Currently is used to combine the triggers into a single value using bitwise OR, 
+        // aswell as to retrieve the triggers from a bitwise OR value. 
+        //
+        // It can also be used for other purposes.
+        val availableTriggers: List<Int> = listOf(
+            Geofence.GEOFENCE_TRANSITION_ENTER,
+            Geofence.GEOFENCE_TRANSITION_EXIT,
+            Geofence.GEOFENCE_TRANSITION_DWELL,
+        )
+    }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -68,11 +68,9 @@ class _MyAppState extends State<MyApp> {
     await Permission.locationAlways.request();
     await Permission.notification.request();
 
-    _hasServiceStarted =
-        await GeofenceForegroundService().startGeofencingService(
+    _hasServiceStarted = await GeofenceForegroundService().startGeofencingService(
       contentTitle: 'Test app is running in the background',
-      contentText:
-          'Test app will be running to ensure seamless integration with ops team',
+      contentText: 'Test app will be running to ensure seamless integration with ops team',
       notificationChannelId: 'com.app.geofencing_notifications_channel',
       serviceId: 525600,
       isInDebugMode: true,
@@ -99,6 +97,14 @@ class _MyAppState extends State<MyApp> {
         radius: 1000, // measured in meters
         coordinates: [_londonCityCenter],
         notificationResponsivenessMs: 15 * 1000, // 15 seconds
+        triggers: [
+          GeofenceEventType.dwell,
+          GeofenceEventType.enter,
+          GeofenceEventType.exit
+        ], // Currently, only available on Android
+        expirationDuration: const Duration(days: 1), // Currently, only available on Android
+        dwellLoiteringDelay: const Duration(hours: 1), // Currently, only available on Android
+        initialTrigger: GeofenceEventType.enter, // Currently, only available on Android
       ),
     );
   }

--- a/lib/constants/api_methods.dart
+++ b/lib/constants/api_methods.dart
@@ -1,0 +1,11 @@
+import 'dart:core';
+
+class ApiMethods {
+  static const String startGeofencingService = "startGeofencingService";
+  static const String stopGeofencingService = "stopGeofencingService";
+  static const String isForegroundServiceRunning = "isForegroundServiceRunning";
+  static const String addGeofence = "addGeofence";
+  static const String addGeoFences = "addGeoFences";
+  static const String removeGeofence = "removeGeofence";
+  static const String removeAllGeoFences = "removeAllGeoFences";
+}

--- a/lib/constants/geofence_event_type.dart
+++ b/lib/constants/geofence_event_type.dart
@@ -7,21 +7,24 @@ enum GeofenceEventType {
   final int value;
 
   const GeofenceEventType(this.value);
+
+  /// Return a value based on the [id].
+  ///
+  /// If no value is found, or [id] is null, it will return [GeofenceEventType.unKnown].
+  static GeofenceEventType findById([int? id]) => GeofenceEventType.values.firstWhere(
+        (element) => element.value == id,
+        orElse: () => GeofenceEventType.unKnown,
+      );
 }
 
 extension GeofenceEventTypeIntX on int {
-  GeofenceEventType toGeofenceEventType() {
-    switch (this) {
-      case 1:
-        return GeofenceEventType.enter;
-      case 2:
-        return GeofenceEventType.exit;
-      case 3:
-        return GeofenceEventType.dwell;
-      default:
-        return GeofenceEventType.unKnown;
-    }
-  }
+  /// Convert an integer to a [GeofenceEventType].
+  ///
+  /// If the value doesn't match any [GeofenceEventType], it will
+  /// return [GeofenceEventType.unKnown].
+  ///
+  /// This method is a shorthand for [GeofenceEventType.findById].
+  GeofenceEventType toGeofenceEventType() => GeofenceEventType.findById(this);
 }
 
 extension GeofenceEventTypeX on GeofenceEventType {

--- a/lib/constants/json_keys.dart
+++ b/lib/constants/json_keys.dart
@@ -5,8 +5,11 @@ class JsonKeys {
   static const String coordinates = 'coordinates';
   static const String latitude = 'latitude';
   static const String longitude = 'longitude';
-  static const String notificationResponsivenessMs =
-      'notification_responsiveness_ms';
+  static const String notificationResponsivenessMs = 'notification_responsiveness_ms';
+  static const String fenceTriggers = "fence_triggers";
+  static const String fenceExpirationDuration = "fence_expiration_duration";
+  static const String dwellLoiteringDelay = "fence_dwell_loitering_delay";
+  static const String initialTrigger = "fence_initial_trigger";
 
   static const String channelId = 'channel_id';
   static const String contentTitle = 'content_title';

--- a/lib/geofence_foreground_service_method_channel.dart
+++ b/lib/geofence_foreground_service_method_channel.dart
@@ -13,16 +13,15 @@ import 'models/background_task_handlers.dart';
 import 'models/notification_icon_data.dart';
 
 /// An implementation of [GeofenceForegroundServicePlatform] that uses method channels.
-class MethodChannelGeofenceForegroundService
-    extends GeofenceForegroundServicePlatform {
+class MethodChannelGeofenceForegroundService extends GeofenceForegroundServicePlatform {
   /// The method channel used to interact with the native platform.
   @visibleForTesting
-  final foregroundChannel = const MethodChannel(
-      'ps.byshy.geofence/foreground_geofence_foreground_service');
+  final foregroundChannel =
+      const MethodChannel('ps.byshy.geofence/foreground_geofence_foreground_service');
 
   @visibleForTesting
-  final backgroundChannel = const MethodChannel(
-      "ps.byshy.geofence/background_geofence_foreground_service");
+  final backgroundChannel =
+      const MethodChannel("ps.byshy.geofence/background_geofence_foreground_service");
 
   /// This method is used to start the geofencing foreground service
   @override
@@ -91,9 +90,7 @@ class MethodChannelGeofenceForegroundService
 
       return backgroundTriggerHandler(
         call.arguments['ps.byshy.geofence.ZONE_ID'],
-        inputData == null
-            ? GeofenceEventType.unKnown
-            : (jsonDecode(inputData) as int).toGeofenceEventType(),
+        GeofenceEventType.findById(jsonDecode(inputData) as int?),
       );
     });
 
@@ -106,9 +103,7 @@ class MethodChannelGeofenceForegroundService
     bool didStop = false;
 
     try {
-      didStop = await foregroundChannel
-              .invokeMethod<bool?>('stopGeofencingService') ??
-          false;
+      didStop = await foregroundChannel.invokeMethod<bool?>('stopGeofencingService') ?? false;
     } catch (e) {
       log(
         e.toString(),
@@ -125,9 +120,8 @@ class MethodChannelGeofenceForegroundService
     bool isServiceRunning = false;
 
     try {
-      isServiceRunning = await foregroundChannel
-              .invokeMethod<bool?>('isForegroundServiceRunning') ??
-          false;
+      isServiceRunning =
+          await foregroundChannel.invokeMethod<bool?>('isForegroundServiceRunning') ?? false;
     } catch (e) {
       log(
         e.toString(),
@@ -193,8 +187,7 @@ class MethodChannelGeofenceForegroundService
 
     try {
       areAllAreasRemoved =
-          await foregroundChannel.invokeMethod<bool?>('removeAllGeoFences') ??
-              false;
+          await foregroundChannel.invokeMethod<bool?>('removeAllGeoFences') ?? false;
     } catch (e) {
       log(
         e.toString(),

--- a/lib/geofence_foreground_service_method_channel.dart
+++ b/lib/geofence_foreground_service_method_channel.dart
@@ -7,6 +7,7 @@ import 'package:flutter/widgets.dart';
 import 'package:geofence_foreground_service/constants/geofence_event_type.dart';
 import 'package:geofence_foreground_service/models/zone.dart';
 
+import 'constants/api_methods.dart';
 import 'constants/json_keys.dart';
 import 'geofence_foreground_service_platform_interface.dart';
 import 'models/background_task_handlers.dart';
@@ -22,6 +23,9 @@ class MethodChannelGeofenceForegroundService extends GeofenceForegroundServicePl
   @visibleForTesting
   final backgroundChannel =
       const MethodChannel("ps.byshy.geofence/background_geofence_foreground_service");
+
+  Future<T?> _invokeMethod<T>(String method, [dynamic arguments]) =>
+      foregroundChannel.invokeMethod(method, arguments);
 
   /// This method is used to start the geofencing foreground service
   @override
@@ -60,11 +64,7 @@ class MethodChannelGeofenceForegroundService extends GeofenceForegroundServicePl
       bool didStart = false;
 
       try {
-        didStart = await foregroundChannel.invokeMethod<bool?>(
-              'startGeofencingService',
-              data,
-            ) ??
-            false;
+        return await _invokeMethod<bool?>(ApiMethods.startGeofencingService, data) ?? false;
       } catch (e) {
         log(
           e.toString(),
@@ -103,7 +103,7 @@ class MethodChannelGeofenceForegroundService extends GeofenceForegroundServicePl
     bool didStop = false;
 
     try {
-      didStop = await foregroundChannel.invokeMethod<bool?>('stopGeofencingService') ?? false;
+      return await _invokeMethod<bool?>(ApiMethods.stopGeofencingService) ?? false;
     } catch (e) {
       log(
         e.toString(),
@@ -120,8 +120,7 @@ class MethodChannelGeofenceForegroundService extends GeofenceForegroundServicePl
     bool isServiceRunning = false;
 
     try {
-      isServiceRunning =
-          await foregroundChannel.invokeMethod<bool?>('isForegroundServiceRunning') ?? false;
+      return await _invokeMethod<bool?>(ApiMethods.isForegroundServiceRunning) ?? false;
     } catch (e) {
       log(
         e.toString(),
@@ -140,11 +139,7 @@ class MethodChannelGeofenceForegroundService extends GeofenceForegroundServicePl
     bool isGeofenceAdded = false;
 
     try {
-      isGeofenceAdded = await foregroundChannel.invokeMethod<bool?>(
-            'addGeofence',
-            zone.toJson(),
-          ) ??
-          false;
+      return await _invokeMethod<bool?>(ApiMethods.addGeofence, zone.toJson()) ?? false;
     } catch (e) {
       log(
         e.toString(),
@@ -163,12 +158,7 @@ class MethodChannelGeofenceForegroundService extends GeofenceForegroundServicePl
     bool isGeofenceRemoved = false;
 
     try {
-      isGeofenceRemoved = await foregroundChannel.invokeMethod<bool?>(
-            'removeGeofence',
-            {
-              JsonKeys.zoneId: zoneId,
-            },
-          ) ??
+      return await _invokeMethod<bool?>(ApiMethods.removeGeofence, {JsonKeys.zoneId: zoneId}) ??
           false;
     } catch (e) {
       log(
@@ -186,8 +176,7 @@ class MethodChannelGeofenceForegroundService extends GeofenceForegroundServicePl
     bool areAllAreasRemoved = false;
 
     try {
-      areAllAreasRemoved =
-          await foregroundChannel.invokeMethod<bool?>('removeAllGeoFences') ?? false;
+      return await _invokeMethod<bool?>(ApiMethods.removeAllGeoFences) ?? false;
     } catch (e) {
       log(
         e.toString(),

--- a/lib/models/zone.dart
+++ b/lib/models/zone.dart
@@ -1,10 +1,16 @@
+import 'package:geofence_foreground_service/constants/geofence_event_type.dart';
 import 'package:latlng/latlng.dart';
 
 import '../constants/json_keys.dart';
 
 class Zone {
+  /// A unique identifier for the geofence zone.
   final String id;
+
+  /// The radius of the geofence zone in meters.
   final double radius;
+
+  /// List of coordinates of the geofence zone.
   final List<LatLng> coordinates;
 
   /// The millisecond delay between entering the zone and receiving the
@@ -19,46 +25,99 @@ class Zone {
   /// geofence might adjust the responsiveness value to save power when needed.
   final int? notificationResponsivenessMs;
 
+  /// The list of triggers that will be used to monitor the geofence zone.
+  ///
+  /// The default value contains all available triggers. Which are: enter, exit, and dwell.
+  ///
+  /// The current implementation for this field is only supported on Android devices.
+  ///
+  /// There is no ETA for iOS support.
+  final List<GeofenceEventType> triggers;
+
+  /// The duration after which the geofence will expire.
+  ///
+  /// If the value is not provided the geofence will have no expiration duration.
+  ///
+  /// The current implementation for this field is only supported on Android devices.
+  final Duration? expirationDuration;
+
+  /// The time it will take to trigger the dwell event after the user enters the geofence zone.
+  ///
+  /// If not provided, it means that the event should be triggered immediately.
+  ///
+  /// The current implementation for this field is only supported on Android devices.
+  final Duration? dwellLoiteringDelay;
+
+  /// The initial trigger for the geofence zone.
+  ///
+  /// If, at the moment of adding the geofence, the initial trigger matches one of the triggers,
+  /// the event will be triggered.
+  ///
+  /// For example: if the initial trigger is set to [GeofenceEventType.enter] and the user is
+  /// inside the geofence zone when the zone is added, the [GeofenceEventType.enter] event will
+  /// be triggered.
+  ///
+  /// The default value is [GeofenceEventType.enter].
+  ///
+  /// The current implementation for this field is only supported on Android devices.
+  final GeofenceEventType initialTrigger;
+
   Zone({
     required this.id,
     required this.radius,
     required this.coordinates,
     this.notificationResponsivenessMs,
+    this.triggers = const [
+      GeofenceEventType.enter,
+      GeofenceEventType.exit,
+      GeofenceEventType.dwell,
+    ],
+    this.expirationDuration,
+    this.dwellLoiteringDelay,
+    this.initialTrigger = GeofenceEventType.enter,
   });
 
-  factory Zone.fromJson(Map<String, dynamic> json) {
-    List<LatLng> jsonCoordinates = [];
+  factory Zone.fromJson(Map<String, dynamic> json) => Zone(
+        id: json[JsonKeys.id] as String,
+        radius: json[JsonKeys.radius] as double,
+        coordinates: _coordinatesFromJson(json[JsonKeys.coordinates]),
+        notificationResponsivenessMs: json[JsonKeys.notificationResponsivenessMs],
+        triggers: _triggersFromJson(json[JsonKeys.fenceTriggers]),
+        expirationDuration: json[JsonKeys.fenceExpirationDuration] != null
+            ? Duration(milliseconds: json[JsonKeys.fenceExpirationDuration] as int)
+            : null,
+        dwellLoiteringDelay: json[JsonKeys.dwellLoiteringDelay] != null
+            ? Duration(milliseconds: json[JsonKeys.dwellLoiteringDelay] as int)
+            : null,
+        initialTrigger: GeofenceEventType.findById(json[JsonKeys.initialTrigger] as int?),
+      );
 
-    if (json[JsonKeys.coordinates] != null) {
-      List coordinatesJsonList = json[JsonKeys.coordinates] as List;
-
-      for (Map<String, double> coordinates in coordinatesJsonList) {
-        jsonCoordinates.add(LatLng.degree(
-          coordinates[JsonKeys.latitude]!,
-          coordinates[JsonKeys.longitude]!,
-        ));
-      }
-    }
-
-    return Zone(
-      id: json[JsonKeys.id],
-      radius: json[JsonKeys.radius],
-      coordinates: jsonCoordinates,
-      notificationResponsivenessMs: json[JsonKeys.notificationResponsivenessMs],
-    );
-  }
-
-  Map<String, dynamic> toJson() {
-    return {
-      JsonKeys.id: id,
-      JsonKeys.radius: radius,
-      JsonKeys.coordinates: coordinates
-          .map((e) => {
-                JsonKeys.latitude: e.latitude.degrees,
-                JsonKeys.longitude: e.longitude.degrees,
-              })
-          .toList(),
-      JsonKeys.notificationResponsivenessMs: notificationResponsivenessMs,
-    };
-  }
+  Map<String, dynamic> toJson() => {
+        JsonKeys.id: id,
+        JsonKeys.radius: radius,
+        JsonKeys.coordinates: coordinates
+            .map((e) => {
+                  JsonKeys.latitude: e.latitude.degrees,
+                  JsonKeys.longitude: e.longitude.degrees,
+                })
+            .toList(),
+        JsonKeys.notificationResponsivenessMs: notificationResponsivenessMs,
+        JsonKeys.fenceTriggers: triggers.map((e) => e.value).toList(),
+        JsonKeys.fenceExpirationDuration: expirationDuration?.inMilliseconds,
+        JsonKeys.dwellLoiteringDelay: dwellLoiteringDelay?.inMilliseconds,
+        JsonKeys.initialTrigger: initialTrigger.value,
+      };
 }
+
+List<LatLng> _coordinatesFromJson(List<dynamic>? coordinatesJsonList) => List.generate(
+      coordinatesJsonList?.length ?? 0,
+      (index) {
+        final coordinates = coordinatesJsonList![index] as Map<String, double>;
+        return LatLng.degree(coordinates[JsonKeys.latitude]!, coordinates[JsonKeys.longitude]!);
+      },
+    );
+
+List<GeofenceEventType> _triggersFromJson(List<dynamic>? triggersJsonList) => List.generate(
+      triggersJsonList?.length ?? 0,
+      (index) => GeofenceEventType.findById(triggersJsonList![index] as int?),
+    );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geofence_foreground_service
 description: A Flutter project that creates a foreground service to handle geofencing.
-version: 1.1.3
+version: 1.1.4
 repository: https://github.com/Basel-525k/geofence_foreground_service
 license: Apache-2.0
 


### PR DESCRIPTION
Hello, took some time because we had a lot of work 

Added the following options to the geofence Zone:
- triggers, used to pass triggers independently
- expirationDuration, used for adding temporary geofences
- dwellLoiteringDelay, used to add a delay for when the device is considered to loiter inside a geofence (Issue #11)
- initialTrigger, provide an initial trigger which is triggered if the conditions are met when adding a geofence

Updated fromJson/toJson functions to include the new fields.

Did some refactoring to try and make the code more readable. Hope it's not an issue with you.

I tried to make more isolated commits, so you can cherry pick what you want and discard what you don't want.

Let me know if you want to modify/revert some of the code, or you find any issues.