### PR TITLE
Fix service crash on Android and ensure clean stop:

### DIFF
--- a/android/src/main/kotlin/com/f2fk/geofence_foreground_service/GeofenceForegroundServicePlugin.kt
+++ b/android/src/main/kotlin/com/f2fk/geofence_foreground_service/GeofenceForegroundServicePlugin.kt
@@ -119,7 +119,10 @@ class GeofenceForegroundServicePlugin : FlutterPlugin, MethodCallHandler, Activi
 
     private fun stopGeofencingService(result: Result) {
         try {
-            context.stopService(serviceIntent)
+            val stopIntent = Intent(context, GeofenceForegroundService::class.java).apply {
+                putExtra(context.extraNameGen(Constants.geofenceAction), GeofenceServiceAction.STOP.name)
+            }
+            context.startService(stopIntent)
             result.success(true)
         } catch (e: Exception) {
             result.success(false)

--- a/android/src/main/kotlin/com/f2fk/geofence_foreground_service/enums/GeofenceServiceAction.kt
+++ b/android/src/main/kotlin/com/f2fk/geofence_foreground_service/enums/GeofenceServiceAction.kt
@@ -1,5 +1,5 @@
 package com.f2fk.geofence_foreground_service.enums
 
 enum class GeofenceServiceAction {
-    SETUP, TRIGGER
+    SETUP, TRIGGER, STOP
 }


### PR DESCRIPTION
### **Description**
- Added a background location permission check to ensure the service stops gracefully if permissions are revoked while the app is running in the background.

- Utilized FOREGROUND_SERVICE_TYPE_LOCATION for startForeground to comply with Android's foreground service requirements.

- Implemented proper handling of the STOP action to stop the service and remove the notification, ensuring a clean shutdown.

### **Benefits**

- Prevents crashes when the user changes location permissions while the service is running in the background.
- Ensures the background service stops successfully without leaving any lingering notifications.
- Improves user experience by removing the foreground notification when the service is stopped via stopGeofencingService.

@Basel-525k @byshy 
This change ensures the geofencing service behaves reliably and adheres to Android's background service policies.